### PR TITLE
Allow strings for svelte node in config file

### DIFF
--- a/loadConfig.js
+++ b/loadConfig.js
@@ -28,8 +28,8 @@ exports.load = async function load({ config, options, logger }) {
   const { contents } = configFile;
   const isDynamic = path.extname(configFile.filePath) === '.js';
 
-  if (typeof contents !== 'object') {
-    throw new Error('Svelte config should be an object.');
+  if (typeof contents !== 'object' && typeof contents !== 'string') {
+    throw new Error('Svelte config should be an object or a string.');
   }
 
   if (isDynamic) {


### PR DESCRIPTION
This fixes issue #18 by checking for objects as well as strings.
Tested locally and should work with a string set in the svelte object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orlov-vo/parcel-transformer-svelte/26)
<!-- Reviewable:end -->
